### PR TITLE
Drop public-key and audience inputs, clarify others

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,9 +43,7 @@ for server configuration and advanced options.
 | Input | Required | Description |
 |---|---|---|
 | `server-url` | yes | niks3 server URL |
-| `substituter` | no | override the substituter URL (defaults from server) |
-| `public-key` | no | override the trusted public keys (defaults from server) |
-| `audience` | no | override the OIDC audience (defaults from server) |
+| `substituter` | no | override the substituter URL, e.g. a CDN mirror (defaults from server) |
 | `skip-push` | no | configure the substituter only, don't upload |
 | `drain-timeout` | no | seconds to wait for uploads to finish in the post step (default 600) |
 | `niks3-bin` | no | path to a niks3 binary, instead of downloading the release |

--- a/action.yml
+++ b/action.yml
@@ -13,21 +13,13 @@ inputs:
     description: >-
       Override the substituter URL written to nix.conf. Defaults to the server's configured cache-url.
     required: false
-  public-key:
-    description: >-
-      Override the trusted public key(s), space-separated. Defaults to the server's signing keys.
-    required: false
-  audience:
-    description: >-
-      Override the OIDC audience to request from GitHub. Defaults to the audience the server has configured for the GitHub issuer.
-    required: false
   skip-push:
     description: >-
       Only configure the substituter; do not push build outputs.
     default: 'false'
   niks3-bin:
     description: >-
-      Path to a niks3 binary. Defaults to downloading the release that matches this action's tag.
+      Path to a niks3 binary. Defaults to downloading the pinned niks3 release.
     required: false
   drain-timeout:
     description: >-
@@ -35,7 +27,7 @@ inputs:
     default: '600'
   debug:
     description: >-
-      Enable debug logging from the niks3 binary.
+      Enable debug logging.
     default: 'false'
 runs:
   using: node24

--- a/dist/index.cjs
+++ b/dist/index.cjs
@@ -23007,22 +23007,13 @@ async function setup() {
 }
 async function resolveConfig() {
   const serverURL = getInput("server-url", { required: true });
-  let substituter = getInput("substituter");
-  let publicKeys = getInput("public-key").split(/\s+/).filter(Boolean);
-  let audience = getInput("audience");
-  if (!substituter || publicKeys.length === 0 || !audience) {
-    const fetched = await fetchCacheConfig(serverURL);
-    if (fetched) {
-      substituter ||= fetched.substituter_url;
-      if (publicKeys.length === 0) publicKeys = fetched.public_keys;
-      audience ||= fetched.oidc_audience;
-    }
-  }
+  const fetched = await fetchCacheConfig(serverURL);
+  const substituter = getInput("substituter") || fetched?.substituter_url || "";
   return {
     serverURL,
     substituter,
-    publicKeys,
-    audience,
+    publicKeys: fetched?.public_keys ?? [],
+    audience: fetched?.oidc_audience ?? "",
     skipPush: getBooleanInput("skip-push"),
     debug: getBooleanInput("debug")
   };
@@ -23067,7 +23058,7 @@ async function pickMode(cfg) {
   }
   if (!cfg.audience) {
     warning(
-      `no OIDC audience configured \u2014 set the 'audience' input or configure an OIDC provider with issuer ${GITHUB_ISSUER} on the server`
+      `no OIDC audience configured \u2014 configure an OIDC provider with issuer ${GITHUB_ISSUER} on the server`
     );
     return "none";
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -84,25 +84,19 @@ async function setup(): Promise<void> {
 
 async function resolveConfig(): Promise<ResolvedConfig> {
   const serverURL = core.getInput('server-url', { required: true })
-  let substituter = core.getInput('substituter')
-  let publicKeys = core.getInput('public-key').split(/\s+/).filter(Boolean)
-  let audience = core.getInput('audience')
 
-  // Only hit the server if something is missing. Inputs always win.
-  if (!substituter || publicKeys.length === 0 || !audience) {
-    const fetched = await fetchCacheConfig(serverURL)
-    if (fetched) {
-      substituter ||= fetched.substituter_url
-      if (publicKeys.length === 0) publicKeys = fetched.public_keys
-      audience ||= fetched.oidc_audience
-    }
-  }
+  const fetched = await fetchCacheConfig(serverURL)
+
+  // The substituter override exists to point pulls at a CDN/mirror in front
+  // of the cache. Public keys and OIDC audience are tied to the server and
+  // have no sensible override.
+  const substituter = core.getInput('substituter') || fetched?.substituter_url || ''
 
   return {
     serverURL,
     substituter,
-    publicKeys,
-    audience,
+    publicKeys: fetched?.public_keys ?? [],
+    audience: fetched?.oidc_audience ?? '',
     skipPush: core.getBooleanInput('skip-push'),
     debug: core.getBooleanInput('debug'),
   }
@@ -164,7 +158,7 @@ async function pickMode(cfg: ResolvedConfig): Promise<'daemon' | 'storescan' | '
 
   if (!cfg.audience) {
     core.warning(
-      `no OIDC audience configured — set the 'audience' input or configure an OIDC provider with issuer ${GITHUB_ISSUER} on the server`,
+      `no OIDC audience configured — configure an OIDC provider with issuer ${GITHUB_ISSUER} on the server`,
     )
     return 'none'
   }


### PR DESCRIPTION
Public keys and OIDC audience are tied to the server and have no
sensible override; /api/cache-config provides them. The substituter
override stays for pointing pulls at a CDN mirror.

Also clarify the niks3-bin and debug input descriptions.
