### PR TITLE
Rename action to 'niks3 binary cache'

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,4 +1,4 @@
-name: niks3
+name: niks3 binary cache
 description: Push Nix build outputs to a niks3 binary cache with per-derivation caching
 author: Mic92
 branding:


### PR DESCRIPTION
GitHub Marketplace rejects the name 'niks3' because it collides with
the Mic92/niks3 repository name.
