### PR TITLE
fix: use process.execPath for auth-token script invocation

### DIFF
--- a/dist/index.cjs
+++ b/dist/index.cjs
@@ -23179,7 +23179,7 @@ process.stdout.write(JSON.stringify(out))
 `,
     { mode: 384 }
   );
-  return `node ${file}`;
+  return `${process.execPath} ${file}`;
 }
 function writeStoreSnapshot(file) {
   fs4.writeFileSync(file, listStorePaths().join("\n") + "\n");

--- a/src/index.ts
+++ b/src/index.ts
@@ -313,7 +313,7 @@ process.stdout.write(JSON.stringify(out))
     { mode: 0o600 },
   )
 
-  return `node ${file}`
+  return `${process.execPath} ${file}`
 }
 
 // writeStoreSnapshot lists store paths one-per-line. Used in storescan mode.


### PR DESCRIPTION
Self-hosted runners (notably actions-runner-controller containers) don't ship `node` on PATH; the GHA runner bundles its own under externals/node20/ and invokes node actions with that binary directly. The auth-token script was returned as `node <file>`, so when niks3-hook (or storescan's niks3 push) execs it, the lookup fails with "node: executable file not found in $PATH".

process.execPath is the absolute path to the node binary running this action — baking it into the script command makes the exec PATH-independent.