### PR TITLE
ci: run checks on gitea-mq merge branches, skip cache verify on fork PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches: [main]
   pull_request:
+  merge_group:
 
 jobs:
   dist-fresh:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches: [main]
   pull_request:
+  merge_group:
 
 permissions:
   id-token: write
@@ -47,6 +48,10 @@ jobs:
   # cache from within it. A follow-up job curls the .narinfo.
   verify:
     needs: e2e
+    # Fork PRs get no OIDC token, so nothing is pushed and the cache probe
+    # would always fail. The merge queue runs in the base repo with a token,
+    # so the real round-trip is still verified before merge.
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     strategy:
       matrix:


### PR DESCRIPTION
Fork PRs (e.g. #22) have no OIDC token: nothing is pushed and `verify` fails after 300s. Skip `verify` on fork PRs and run workflows on `gitea-mq/**` branches instead, where gitea-mq tests queued PRs in the base repo with a token before auto-merge completes.