### PR TITLE
ci: trigger on gitea-mq/** instead of merge_group

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 name: CI
 on:
   push:
-    branches: [main]
+    branches: [main, 'gitea-mq/**']
   pull_request:
   merge_group:
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,9 +1,8 @@
 name: Test
 on:
   push:
-    branches: [main]
+    branches: [main, 'gitea-mq/**']
   pull_request:
-  merge_group:
 
 permissions:
   id-token: write
@@ -49,8 +48,9 @@ jobs:
   verify:
     needs: e2e
     # Fork PRs get no OIDC token, so nothing is pushed and the cache probe
-    # would always fail. The merge queue runs in the base repo with a token,
-    # so the real round-trip is still verified before merge.
+    # would always fail. gitea-mq pushes the merge branch to the base repo
+    # (gitea-mq/<pr>), where the token exists, so the real round-trip is
+    # still verified before merge.
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     strategy:


### PR DESCRIPTION
merge_group never fires here: merge queue needs an org-owned repo, and this repo now uses gitea-mq instead. gitea-mq tests queued PRs on a gitea-mq/<pr> branch in the base repo, where the push event gets an OIDC token, so the full push/verify round-trip gates merges. Follow-up to #24.