### PR TITLE
fix: wait for niks3-hook serve socket before finishing setup

### DIFF
--- a/dist/index.cjs
+++ b/dist/index.cjs
@@ -23157,6 +23157,12 @@ exec ${q(hookBin)} send --socket ${q(socket)}
   child2.unref();
   fs4.closeSync(logFD);
   if (!child2.pid) throw new Error("failed to start niks3-hook serve: no pid");
+  const deadline = Date.now() + 1e4;
+  while (!fs4.existsSync(socket)) {
+    if (!alive(child2.pid)) throw new Error("niks3-hook serve exited before binding socket");
+    if (Date.now() > deadline) throw new Error(`niks3-hook serve did not bind ${socket} within 10s`);
+    sleepSync(50);
+  }
   info(`niks3-hook serve started (pid ${child2.pid}, socket ${socket})`);
   saveState("daemonPid", String(child2.pid));
   saveState("daemonLog", logPath);

--- a/src/index.ts
+++ b/src/index.ts
@@ -284,6 +284,15 @@ function startDaemon(binDir: string, workDir: string, cfg: ResolvedConfig): void
 
   if (!child.pid) throw new Error('failed to start niks3-hook serve: no pid')
 
+  // serve binds the socket late (after sqlite + `nix eval`); send swallows
+  // connect errors. Block until the socket exists so fast builds aren't lost.
+  const deadline = Date.now() + 10000
+  while (!fs.existsSync(socket)) {
+    if (!alive(child.pid)) throw new Error('niks3-hook serve exited before binding socket')
+    if (Date.now() > deadline) throw new Error(`niks3-hook serve did not bind ${socket} within 10s`)
+    sleepSync(50)
+  }
+
   core.info(`niks3-hook serve started (pid ${child.pid}, socket ${socket})`)
   core.saveState('daemonPid', String(child.pid))
   core.saveState('daemonLog', logPath)


### PR DESCRIPTION
serve binds its unix socket only after opening the sqlite queue and
running `nix eval` to discover the store dir. The action spawned it
detached and returned immediately, so a fast build could fire the
post-build-hook before the socket existed. niks3-hook send always
exits 0 on connect errors, so the path was silently dropped and the
post-step drain found an empty queue.

Observed as flaky verify jobs on multi-user runners; ubuntu-slim was
unaffected because the untrusted runner there falls back to storescan
mode, which does not use the hook.
