### PR TITLE
feat: add setOutput function to handle output values in GitHub Actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,14 @@ for server configuration and advanced options.
 
 ## Outputs
 
+Following outputs are generally available for use in subsequent steps:
+
+| Output | Description |
+|---|---|
+| `binary-dir` | the directory containing the niks3 binary |
+
+Following outputs are only available when the action is working in `daemon` mode:
+
 | Output | Description |
 |---|---|
 | `auth-token-script` | a script that can be used with `niks3 --auth-token-script` to authenticate with the niks3 server |

--- a/README.md
+++ b/README.md
@@ -51,6 +51,13 @@ for server configuration and advanced options.
 | `niks3-bin` | no | path to a niks3 binary, instead of downloading the release |
 | `debug` | no | enable debug logging |
 
+## Outputs
+
+| Output | Description |
+|---|---|
+| `auth-token-script` | a script that can be used with `niks3 --auth-token-script` to authenticate with the niks3 server |
+| `socket` | the path to the socket file that the niks3-hook serve process listens on |
+
 ## Development
 
 ```sh

--- a/action.yml
+++ b/action.yml
@@ -37,6 +37,13 @@ inputs:
     description: >-
       Enable debug logging.
     default: 'false'
+outputs:
+  binary-dir:
+    description: Directory containing the niks3 and niks3-hook binaries.
+  auth-token-script:
+    description: Script printing a fresh OIDC token, for `niks3 --auth-token-script` (daemon mode only).
+  socket:
+    description: Unix socket the niks3-hook serve daemon listens on (daemon mode only).
 runs:
   using: node24
   main: dist/index.cjs

--- a/dist/index.cjs
+++ b/dist/index.cjs
@@ -22566,6 +22566,14 @@ function getBooleanInput(name, options) {
   throw new TypeError(`Input does not meet YAML 1.2 "Core Schema" specification: ${name}
 Support boolean input list: \`true | True | TRUE | false | False | FALSE\``);
 }
+function setOutput(name, value) {
+  const filePath = process.env["GITHUB_OUTPUT"] || "";
+  if (filePath) {
+    return issueFileCommand("OUTPUT", prepareKeyValueMessage(name, value));
+  }
+  process.stdout.write(os5.EOL);
+  issueCommand("set-output", { name }, toCommandValue(value));
+}
 function setFailed(message) {
   process.exitCode = ExitCode.Failure;
   error(message);
@@ -23176,6 +23184,7 @@ exec ${q(hookBin)} send --socket ${q(socket)}
     await sleep(50);
   }
   info(`niks3-hook serve started (pid ${child2.pid}, socket ${socket})`);
+  setOutput("auth-token-script", tokenScript);
   saveState("daemonPid", String(child2.pid));
   saveState("daemonLog", logPath);
 }

--- a/dist/index.cjs
+++ b/dist/index.cjs
@@ -23010,6 +23010,7 @@ async function setup() {
     case "none":
       break;
   }
+  setOutput("binary-dir", binDir);
   saveState("mode", mode);
   saveState("workDir", workDir);
   saveState("binDir", binDir);
@@ -23185,6 +23186,7 @@ exec ${q(hookBin)} send --socket ${q(socket)}
   }
   info(`niks3-hook serve started (pid ${child2.pid}, socket ${socket})`);
   setOutput("auth-token-script", tokenScript);
+  setOutput("socket", socket);
   saveState("daemonPid", String(child2.pid));
   saveState("daemonLog", logPath);
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -301,6 +301,8 @@ async function startDaemon(binDir: string, workDir: string, cfg: ResolvedConfig)
   }
 
   core.info(`niks3-hook serve started (pid ${child.pid}, socket ${socket})`)
+  core.setOutput('auth-token-script', tokenScript)
+  core.setOutput('socket', socket)
   core.saveState('daemonPid', String(child.pid))
   core.saveState('daemonLog', logPath)
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -74,6 +74,7 @@ async function setup(): Promise<void> {
       break
   }
 
+  core.setOutput('binary-dir', binDir)
   core.saveState('mode', mode)
   core.saveState('workDir', workDir)
   core.saveState('binDir', binDir)


### PR DESCRIPTION
This commit introduces a new `setOutput` function to manage output values for GitHub Actions. It sets the 'auth-token-script' and 'socket' outputs when starting the daemon, enhancing the integration with GitHub workflows.